### PR TITLE
modify relay compilation using persisted queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 *.tgz
 coverage
 .DS_Store
+ignore-queries.json

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ __mocks__
 jest.config.js
 compile/
 forms.graphql
+ignore-queries.json

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "scripts": {
     "clean": "rimraf lib",
-    "relay": "relay-compiler --src ./compile/ --schema ./forms.graphql --language typescript --artifactDirectory ./src/relay",
+    "relay": "relay-compiler --src ./compile/ --schema ./forms.graphql --language typescript --artifactDirectory ./src/relay --persist-output ./ignore-queries.json",
     "compile": "npm run clean && tsc",
     "build": "npm run compile && npm run test",
     "test": "cross-env NODE_ENV=test jest --coverage",
-    "format": "prettier --write \"src/**/*.{j,t}s*\"",
-    "format:ci": "prettier --list-different \"src/**/*.{j,t}s*\"",
+    "format": "prettier --write \"src/**/*.ts*\" \"!src/relay/**/*.ts\"",
+    "format:ci": "prettier --list-different \"src/**/*.ts*\" \"!src/relay/**/*.ts\"",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "prepublishOnly": "npm run build"
   },

--- a/src/relay/queryErrorsFieldQuery.graphql.ts
+++ b/src/relay/queryErrorsFieldQuery.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ba8e18eb52805d5035b41fd102a40b1b */
+/* @relayHash 9749f1c8c9c3e858d9542a0ec11bf854 */
 
-import { ConcreteRequest } from 'relay-runtime';
+import { ConcreteRequest } from "relay-runtime";
 export type queryErrorsFieldQueryVariables = {};
 export type queryErrorsFieldQueryResponse = {
     readonly form: {
@@ -20,6 +20,8 @@ export type queryErrorsFieldQuery = {
     readonly variables: queryErrorsFieldQueryVariables;
 };
 
+
+
 /*
 query queryErrorsFieldQuery {
   form {
@@ -34,91 +36,90 @@ query queryErrorsFieldQuery {
 }
 */
 
-const node: ConcreteRequest = (function() {
-    var v0 = [
-        {
-            kind: 'LinkedField',
-            alias: null,
-            name: 'form',
-            storageKey: null,
-            args: null,
-            concreteType: 'EntryForm',
-            plural: false,
-            selections: [
-                {
-                    kind: 'ScalarField',
-                    alias: null,
-                    name: 'isSubmitting',
-                    args: null,
-                    storageKey: null,
-                },
-                {
-                    kind: 'ScalarField',
-                    alias: null,
-                    name: 'isValidating',
-                    args: null,
-                    storageKey: null,
-                },
-                {
-                    kind: 'LinkedField',
-                    alias: null,
-                    name: 'entries',
-                    storageKey: null,
-                    args: null,
-                    concreteType: 'Entry',
-                    plural: true,
-                    selections: [
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'id',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'key',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'error',
-                            args: null,
-                            storageKey: null,
-                        },
-                    ],
-                },
-            ],
-        },
-    ];
-    return {
-        kind: 'Request',
-        fragment: {
-            kind: 'Fragment',
-            name: 'queryErrorsFieldQuery',
-            type: 'Query',
-            metadata: null,
-            argumentDefinitions: [],
-            selections: v0 /*: any*/,
-        },
-        operation: {
-            kind: 'Operation',
-            name: 'queryErrorsFieldQuery',
-            argumentDefinitions: [],
-            selections: v0 /*: any*/,
-        },
-        params: {
-            operationKind: 'query',
-            name: 'queryErrorsFieldQuery',
-            id: null,
-            text:
-                'query queryErrorsFieldQuery {\n  form {\n    isSubmitting\n    isValidating\n    entries {\n      id\n      key\n      error\n    }\n  }\n}\n',
-            metadata: {},
-        },
-    };
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EntryForm",
+    "kind": "LinkedField",
+    "name": "form",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isSubmitting",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isValidating",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Entry",
+        "kind": "LinkedField",
+        "name": "entries",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "key",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "error",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "queryErrorsFieldQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "queryErrorsFieldQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": "9749f1c8c9c3e858d9542a0ec11bf854",
+    "metadata": {},
+    "name": "queryErrorsFieldQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
 })();
 (node as any).hash = '3a7cac5a2c10fdd0c226ef027033689c';
 export default node;

--- a/src/relay/queryFieldFragment.graphql.ts
+++ b/src/relay/queryFieldFragment.graphql.ts
@@ -1,41 +1,43 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ReaderFragment } from 'relay-runtime';
-import { FragmentRefs } from 'relay-runtime';
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type queryFieldFragment = {
     readonly id: string;
     readonly check: string | null;
-    readonly ' $refType': 'queryFieldFragment';
+    readonly " $refType": "queryFieldFragment";
 };
 export type queryFieldFragment$data = queryFieldFragment;
 export type queryFieldFragment$key = {
-    readonly ' $data'?: queryFieldFragment$data;
-    readonly ' $fragmentRefs': FragmentRefs<'queryFieldFragment'>;
+    readonly " $data"?: queryFieldFragment$data;
+    readonly " $fragmentRefs": FragmentRefs<"queryFieldFragment">;
 };
 
+
+
 const node: ReaderFragment = {
-    kind: 'Fragment',
-    name: 'queryFieldFragment',
-    type: 'Entry',
-    metadata: null,
-    argumentDefinitions: [],
-    selections: [
-        {
-            kind: 'ScalarField',
-            alias: null,
-            name: 'id',
-            args: null,
-            storageKey: null,
-        },
-        {
-            kind: 'ScalarField',
-            alias: null,
-            name: 'check',
-            args: null,
-            storageKey: null,
-        },
-    ],
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "queryFieldFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "check",
+      "storageKey": null
+    }
+  ],
+  "type": "Entry"
 };
 (node as any).hash = 'd5b0953bdeb412925ee13444a6be6082';
 export default node;

--- a/src/relay/queryFieldQuery.graphql.ts
+++ b/src/relay/queryFieldQuery.graphql.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash dcfff3d9ea8d483cec6a2916d3f744cc */
+/* @relayHash 0b493a6f66e132f2693f91a5da941414 */
 
-import { ConcreteRequest } from 'relay-runtime';
+import { ConcreteRequest } from "relay-runtime";
 export type queryFieldQueryVariables = {};
 export type queryFieldQueryResponse = {
     readonly form: {
@@ -20,6 +20,8 @@ export type queryFieldQuery = {
     readonly variables: queryFieldQueryVariables;
 };
 
+
+
 /*
 query queryFieldQuery {
   form {
@@ -34,91 +36,90 @@ query queryFieldQuery {
 }
 */
 
-const node: ConcreteRequest = (function() {
-    var v0 = [
-        {
-            kind: 'LinkedField',
-            alias: null,
-            name: 'form',
-            storageKey: null,
-            args: null,
-            concreteType: 'EntryForm',
-            plural: false,
-            selections: [
-                {
-                    kind: 'LinkedField',
-                    alias: null,
-                    name: 'entries',
-                    storageKey: null,
-                    args: null,
-                    concreteType: 'Entry',
-                    plural: true,
-                    selections: [
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'id',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'key',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'value',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'check',
-                            args: null,
-                            storageKey: null,
-                        },
-                        {
-                            kind: 'ScalarField',
-                            alias: null,
-                            name: 'error',
-                            args: null,
-                            storageKey: null,
-                        },
-                    ],
-                },
-            ],
-        },
-    ];
-    return {
-        kind: 'Request',
-        fragment: {
-            kind: 'Fragment',
-            name: 'queryFieldQuery',
-            type: 'Query',
-            metadata: null,
-            argumentDefinitions: [],
-            selections: v0 /*: any*/,
-        },
-        operation: {
-            kind: 'Operation',
-            name: 'queryFieldQuery',
-            argumentDefinitions: [],
-            selections: v0 /*: any*/,
-        },
-        params: {
-            operationKind: 'query',
-            name: 'queryFieldQuery',
-            id: null,
-            text:
-                'query queryFieldQuery {\n  form {\n    entries {\n      id\n      key\n      value\n      check\n      error\n    }\n  }\n}\n',
-            metadata: {},
-        },
-    };
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EntryForm",
+    "kind": "LinkedField",
+    "name": "form",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Entry",
+        "kind": "LinkedField",
+        "name": "entries",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "key",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "value",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "check",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "error",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "queryFieldQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query"
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "queryFieldQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": "0b493a6f66e132f2693f91a5da941414",
+    "metadata": {},
+    "name": "queryFieldQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
 })();
 (node as any).hash = 'f9fd20a80a839dfb51206c305cbb1657';
 export default node;


### PR DESCRIPTION
This change allows you to reduce the bundle size by removing the query text in favor of the id